### PR TITLE
Changed repoKey under the resolve section to jcenter instead of repo

### DIFF
--- a/gradle-examples/gradle-example-publish/build.gradle
+++ b/gradle-examples/gradle-example-publish/build.gradle
@@ -125,6 +125,6 @@ artifactory {
         }
     }
     resolve {
-        repoKey = 'repo'
+        repoKey = 'jcenter'
     }
 }


### PR DESCRIPTION
repo is bad. also its disabled since version 3.something so everyone who tries to build this with a recent version will fail due to that.