### PR TITLE
Gradle examples updates.

### DIFF
--- a/gradle-examples/gradle-android-aar/build.gradle
+++ b/gradle-examples/gradle-android-aar/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:0.9.2'
         classpath 'com.github.dcendents:android-maven-plugin:1.0'
-        classpath 'org.jfrog.buildinfo:build-info-extractor-gradle:3.1.1'
+        classpath 'org.jfrog.buildinfo:build-info-extractor-gradle:3.1.2'
     }
 }
 

--- a/gradle-examples/gradle-example-ci-server/services/webservice/build.gradle
+++ b/gradle-examples/gradle-example-ci-server/services/webservice/build.gradle
@@ -3,5 +3,6 @@ apply plugin: 'war'
 dependencies {
     compile project(':shared'), 'commons-collections:commons-collections:3.2@jar', 'commons-io:commons-io:1.2', 'commons-lang:commons-lang:2.4@jar'
     compile group: 'org.apache.wicket', name: 'wicket', version: '1.3.7'
+    compile group: 'junit', name: 'junit', version: '4.11'
     compile project(':api')
 }

--- a/gradle-examples/gradle-example-minimal/build.gradle
+++ b/gradle-examples/gradle-example-minimal/build.gradle
@@ -19,7 +19,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath(group: 'org.jfrog.buildinfo', name: 'build-info-extractor-gradle', version: '3.1.1')
+        classpath(group: 'org.jfrog.buildinfo', name: 'build-info-extractor-gradle', version: '3.1.2')
     }
 }
 

--- a/gradle-examples/gradle-example-publish/build.gradle
+++ b/gradle-examples/gradle-example-publish/build.gradle
@@ -19,7 +19,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath(group: 'org.jfrog.buildinfo', name: 'build-info-extractor-gradle', version: '3.1.1')
+        classpath(group: 'org.jfrog.buildinfo', name: 'build-info-extractor-gradle', version: '3.1.2')
     }
     configurations.classpath {
         resolutionStrategy {

--- a/gradle-examples/gradle-example/build.gradle
+++ b/gradle-examples/gradle-example/build.gradle
@@ -18,7 +18,7 @@ buildscript {
   repositories {
     jcenter()
     dependencies {
-      classpath(group: 'org.jfrog.buildinfo', name: 'build-info-extractor-gradle', version: '3.1.1')
+      classpath(group: 'org.jfrog.buildinfo', name: 'build-info-extractor-gradle', version: '3.1.2')
     }
   }
 }


### PR DESCRIPTION
Gradle examples updates:
Added a missing dependency to gradle-example-ci-server and update the Artifactory Plugin version.