### PR TITLE
Gradle 4 gradle example fixes

### DIFF
--- a/gradle-examples/gradle-example/build.gradle
+++ b/gradle-examples/gradle-example/build.gradle
@@ -112,8 +112,12 @@ artifactory {
     }
   }
   resolve {
+    // this should be set to your local Artifactory instance e.g. http://localhost:8081/artifactory .  Using jcenter here so the project builds.
+    contextUrl = 'https://jcenter.bintray.com'
+    // contextUrl = 'http://localhost:8081/artifactory'
     repository {
-      repoKey = 'jcenter' // The Artifactory (preferably virtual) repository key to resolve from
+      repoKey = '/' // The Artifactory (preferably virtual) repository key to resolve from. This is '/' to use jcenter for this build.
+      // repoKey = 'jcenter' // The Artifactory (preferably virtual) repository key to resolve from
       username = "${artifactory_user}" // Optional resolver user name (leave out to use anonymous resolution)
       password = "${artifactory_password}" // The resolver password
       maven = true     


### PR DESCRIPTION
Make this project build by bumping the Gradle (via wrapper) version to current 4.3.1, and making the project resolve via jcenter in the example.

Fixes #95.