### PR TITLE
Fixed early build-failure caused by missing Artifactory-plugin:

### DIFF
--- a/gradle-examples/4/gradle-example-ci-server-bintray-info/build.gradle
+++ b/gradle-examples/4/gradle-example-ci-server-bintray-info/build.gradle
@@ -18,6 +18,9 @@ buildscript {
   repositories {
     jcenter()
   }
+  dependencies {
+    classpath(group: 'org.jfrog.buildinfo', name: 'build-info-extractor-gradle', version: '4.+')
+  }
 }
 
 def projectUrl = 'https://github.com/eyalbe4/project-examples'
@@ -26,6 +29,7 @@ def bintrayInfoFile = file("$rootDir/bintray-info.json")
 allprojects {
   apply plugin: 'java'
   apply plugin: 'maven'
+  apply plugin: 'com.jfrog.artifactory'
 
   group = 'org.jfrog.example.gradle'
   version = currentVersion

--- a/gradle-examples/4/gradle-example-ci-server/build.gradle
+++ b/gradle-examples/4/gradle-example-ci-server/build.gradle
@@ -18,11 +18,15 @@ buildscript {
   repositories {
     jcenter()
   }
+  dependencies {
+    classpath(group: 'org.jfrog.buildinfo', name: 'build-info-extractor-gradle', version: '4.+')
+  }
 }
 
 allprojects {
   apply plugin: 'java'
   apply plugin: 'maven'
+  apply plugin: 'com.jfrog.artifactory'
 
   group = 'org.jfrog.example.gradle'
   version = '1.0'


### PR DESCRIPTION
* Where:
Build file '/Users/bsrandal/git/project-examples/gradle-examples/4/gradle-example-ci-server-bintray-info/build.gradle' line: 103

* What went wrong:
A problem occurred evaluating root project 'gradle-example-ci-server-bintray-info'.
> Could not get unknown property 'artifactoryPublish' for root project 'gradle-example-ci-server-bintray-info' of type org.gradle.api.Project.