### PR TITLE
Openshift s2i examples

### DIFF
--- a/openshift-s2i-examples/cpp-conan/.s2i/bin/assemble
+++ b/openshift-s2i-examples/cpp-conan/.s2i/bin/assemble
@@ -1,0 +1,16 @@
+cp -Rf /tmp/src/. /opt/app-root/
+
+# conan remote add conan-community https://api.bintray.com/conan/conan-community/conan
+#conan remote add conan-local $ART_CONAN_URL
+
+cd /opt/app-root/
+
+echo "Running conan install build missing"
+conan install . --build missing
+
+echo "Running cmake commands"
+cmake . -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release
+cmake --build .
+
+# conan upload * --all -r conan-local --confirm
+

--- a/openshift-s2i-examples/cpp-conan/.s2i/bin/run
+++ b/openshift-s2i-examples/cpp-conan/.s2i/bin/run
@@ -1,0 +1,4 @@
+#!/bin/bash
+echo "Running Timer C++ Application"
+cd $HOME && ./bin/timer
+

--- a/openshift-s2i-examples/cpp-conan/Dockerfile
+++ b/openshift-s2i-examples/cpp-conan/Dockerfile
@@ -1,0 +1,27 @@
+FROM centos/devtoolset-7-toolchain-centos7 
+
+MAINTAINER Ankush Chadha <ankushc@jfrog.com>
+
+USER 0
+
+RUN INSTALL_PKGS="git make cmake epel-release" && \
+	yum install -y --setopt=tsflags=nodocs install $INSTALL_PKGS && \
+	rpm -V $INSTALL_PKGS && \
+	yum clean all
+
+RUN yum install -y python-pip && pip install conan
+
+ENV GIT_COMMITTER_EMAIL=ankushc@jfrog.com
+ENV GIT_COMMITTER_NAME=AnkushC
+
+COPY ./.s2i/bin/ /usr/local/s2i
+
+LABEL io.openshift.s2i.scripts-url="image:///usr/local/s2i"
+RUN mkdir -p /opt/app-root && chown -R 1001:0 /opt/app-root
+ENV HOME=/opt/app-root
+ENV ART_CONAN_URL=
+USER 1001
+WORKDIR ${HOME}
+CMD ["echo","S2I Builder image to build C++ application via Conan"]
+
+ 

--- a/openshift-s2i-examples/cpp-conan/README.md
+++ b/openshift-s2i-examples/cpp-conan/README.md
@@ -1,0 +1,6 @@
+# How to containerize C++ applications using Conan and OpenShift S2I #
+
+* git clone
+* docker build -t cpp-conan-builder:0.1 .
+* s2i build https://github.com/memsharded/example-poco-timer cpp-conan-builder:0.1 timer-app:0.1
+* docker run -it timer-app:0.1

--- a/openshift-s2i-examples/cpp-conan/README.md
+++ b/openshift-s2i-examples/cpp-conan/README.md
@@ -1,6 +1,26 @@
 # How to containerize C++ applications using Conan and OpenShift S2I #
 
-* git clone
-* docker build -t cpp-conan-builder:0.1 .
-* s2i build https://github.com/memsharded/example-poco-timer cpp-conan-builder:0.1 timer-app:0.1
-* docker run -it timer-app:0.1
+## Clone project ##
+``` git clone https://github.com/JFrogDev/project-examples.git && cd project-examples/openshift-s2i-examples/cpp-conan ```
+
+## Install source-to-image / s2i / sti ##
+Follow the [instructions](https://github.com/openshift/source-to-image#installation) to install s2i
+
+## Generate the builder image that includes conan, make, gcc 7.x ##
+``` docker build -t cpp-conan-builder:0.1 . ```
+
+* The builder image uses [conan](http://docs.conan.io/en/latest/introduction.html) to modularize a C++ application.
+
+
+## Containerize C++ application using s2i ##
+```s2i build https://github.com/memsharded/example-poco-timer cpp-conan-builder:0.1 timer-app:0.1```
+
+* C++ dependencies including the transitive dependencies are pulled from conan-center. 
+* C++ packages can also be pulled from Artifactory since conan repositories are supported.
+``` s2i build https://github.com/memsharded/example-poco-timer cpp-conan-builder:0.1 timer-app:0.2 -e "ART_CONAN_URL=http://art-url/artifactory/api/conan/conan-local" ```
+
+
+## Run your C++ application ##
+```docker run -it timer-app:0.1```
+
+


### PR DESCRIPTION
Adding examples to dockerize a C++ application using OpenShift S2I. This includes a builder image that is conan enabled i.e. it downloads c++ packages from conan-center or from the conan repository in Artifactory.
